### PR TITLE
Fix category icons and daily edit duration inputs

### DIFF
--- a/tasks/templates/tasks/daily_tasks.html
+++ b/tasks/templates/tasks/daily_tasks.html
@@ -393,7 +393,36 @@
                 <div id="edit-form-{{ task.id }}" class="edit-form task-form-container">
                     <form method="post" action="{% url 'edit_task' task.id %}">
                         {% csrf_token %}
-                        {{ edit_forms|dict_get:task.id|safe }}
+                        <p>
+                            <label>Title:</label><br>
+                            <input type="text" name="title" value="{{ task.title }}">
+                        </p>
+                        <p>
+                            <label>Description:</label><br>
+                            <textarea name="description">{{ task.description }}</textarea>
+                        </p>
+                        <p>
+                            <label>Deadline:</label><br>
+                            <input type="date" name="deadline" value="{{ task.deadline|date:'Y-m-d' }}">
+                        </p>
+                        <p>
+                            <label>Goal date:</label><br>
+                            <input type="date" name="goal_date" value="{{ task.goal_date|date:'Y-m-d' }}">
+                        </p>
+                        <div class="time-input-group">
+                            <label style="margin-right: 10px;">Estimated Duration:</label>
+                            <input type="number" name="estimated_hours" min="0" value="{{ task.estimated_time|seconds_to_hours }}">
+                            <input type="number" name="estimated_minutes" min="0" max="59" value="{{ task.estimated_time|seconds_to_minutes }}">
+                            <input type="number" name="estimated_seconds" min="0" max="59" value="{{ task.estimated_time|seconds_to_seconds }}">
+                        </div>
+                        <p>
+                            <label>Category:</label><br>
+                            <input type="text" name="category" value="{{ task.category }}">
+                        </p>
+                        <p>
+                            <label>Category color:</label><br>
+                            <input type="color" name="category_color" value="{{ task.category_color }}">
+                        </p>
                         <button type="submit" class="save-btn">Save Changes</button>
                         <button type="button" class="delete-btn" onclick="toggleForm('edit-form-{{ task.id }}')">Cancel</button>
                     </form>

--- a/tasks/templates/tasks/weekly_tasks.html
+++ b/tasks/templates/tasks/weekly_tasks.html
@@ -337,6 +337,7 @@
                     </button>
                 </form>
                 <div class="task-details">
+                    <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                     <div class="task-title">{{ task.title }}</div>
                     <div class="task-desc">{{ task.description }}</div>
                     <div class="date-info">
@@ -425,6 +426,7 @@
                 </button>
             </form>
             <div class="task-details">
+                <div class="category-symbol" style="color: {{ task.category_color }}">ᯓ★ˎˊ˗</div>
                 <div class="task-title">{{ task.title }}</div>
                 <div class="task-desc">{{ task.description }}</div>
                 <div class="date-info">


### PR DESCRIPTION
## Summary
- restore missing category symbol on weekly tasks
- switch daily task edit form to use hours, minutes, and seconds

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687ab9f4cd388331b6b35bb8bc4cce6e